### PR TITLE
Fehlende Abhängigkeit in pom.xml

### DIFF
--- a/services/chat-server/pom.xml
+++ b/services/chat-server/pom.xml
@@ -6,6 +6,12 @@
   <name>Chat Server</name>
   <url>http://www.informatik.hs-mannheim.de</url>
   <dependencies>
+    <dependency>
+      <groupId>login-server</groupId>
+      <artifactId>login-server</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
     <!-- https://mvnrepository.com/artifact/junit/junit -->
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Bei mir compilieren die Tests erst, nachdem ich eine Abhängigkeit zwischen Chat-Server und Login-Server eingetragen habe.